### PR TITLE
Fix/numpyfloat deprecated

### DIFF
--- a/examples/DeepONet/Lotka-Volterra/scripts/DeepONet_Lotka_Volterra.py
+++ b/examples/DeepONet/Lotka-Volterra/scripts/DeepONet_Lotka_Volterra.py
@@ -107,7 +107,7 @@ input_dataset_sensor_sampled = input_dataset_train[sensors_indices, ...][:, None
 output_target = output_dataset_time_sampled.transpose(2, 0, 1).reshape(
     n_cases * n_time_samples, -1
 )
-output_target_tensor = torch.from_numpy(output_target.astype(np.float32))
+output_target_tensor = torch.from_numpy(output_target.astype("float32"))
 input_branch = np.tile(
     input_dataset_sensor_sampled.transpose(2, 1, 0), (1, n_time_samples, 1)
 ).reshape(n_cases * n_time_samples, -1)

--- a/examples/ESN-RC/scripts/independent_esn_rc_nonlinear_forcing.py
+++ b/examples/ESN-RC/scripts/independent_esn_rc_nonlinear_forcing.py
@@ -19,8 +19,10 @@ import random
 import matplotlib.pyplot as plt
 import numpy as np
 
-from examples.utils.oscillator_solver import (oscillator_solver,
-                                              oscillator_solver_forcing)
+from examples.utils.oscillator_solver import (
+    oscillator_solver,
+    oscillator_solver_forcing,
+)
 from simulai.models import ModelPool
 from simulai.regression import EchoStateNetwork
 from simulai.utilities import make_temp_directory

--- a/examples/MapValid/map_valid_reshaper.py
+++ b/examples/MapValid/map_valid_reshaper.py
@@ -23,8 +23,11 @@ from matplotlib.colors import Normalize
 from simulai.io import BatchCopy, MapValid
 from simulai.metrics import L2Norm, MemorySizeEval
 from simulai.models import ModelPool
-from simulai.normalization import (BatchNormalization, UnitaryNormalization,
-                                   UnitarySymmetricalNormalization)
+from simulai.normalization import (
+    BatchNormalization,
+    UnitaryNormalization,
+    UnitarySymmetricalNormalization,
+)
 from simulai.rom import IPOD
 from simulai.simulation import Pipeline
 

--- a/examples/OpInf/scripts/lorenz_96_chaotic.py
+++ b/examples/OpInf/scripts/lorenz_96_chaotic.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import os
+
 #!/usr/bin/env python
 import warnings
 

--- a/examples/OpInf/scripts/lorenz_96_chaotic_multiple.py
+++ b/examples/OpInf/scripts/lorenz_96_chaotic_multiple.py
@@ -14,6 +14,7 @@
 
 import os
 import time
+
 #!/usr/bin/env python
 import warnings
 

--- a/examples/OpInf/scripts/lorenz_96_stability.py
+++ b/examples/OpInf/scripts/lorenz_96_stability.py
@@ -14,6 +14,7 @@
 
 import os
 import pickle
+
 #!/usr/bin/env python
 import warnings
 from argparse import ArgumentParser

--- a/examples/OpInf/scripts/opinf_nonlinear_network.py
+++ b/examples/OpInf/scripts/opinf_nonlinear_network.py
@@ -25,8 +25,12 @@ os.environ["engine"] = "pytorch"
 from examples.utils.lorenz_solver import lorenz_solver
 from simulai.math.integration import LSODA, ClassWrapper
 from simulai.optimization import Optimizer, ScipyInterface
-from simulai.regression import (AutoEncoderKoopman, DenseNetwork,
-                                KoopmanNetwork, OpInfNetwork)
+from simulai.regression import (
+    AutoEncoderKoopman,
+    DenseNetwork,
+    KoopmanNetwork,
+    OpInfNetwork,
+)
 
 
 class LorenzJacobian:

--- a/examples/OpInf/scripts/svd_lorenz_96_chaotic.py
+++ b/examples/OpInf/scripts/svd_lorenz_96_chaotic.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import os
+
 #!/usr/bin/env python
 import warnings
 

--- a/examples/PINN/scripts/pendulum_system_pytorch_pinn.py
+++ b/examples/PINN/scripts/pendulum_system_pytorch_pinn.py
@@ -26,8 +26,7 @@ from simulai.io import IntersectingBatches
 from simulai.metrics import L2Norm
 from simulai.models import DeepONet, ImprovedDeepONet
 from simulai.optimization import Optimizer
-from simulai.regression import (SLFNN, ConvexDenseNetwork, DenseNetwork,
-                                ResDenseNetwork)
+from simulai.regression import SLFNN, ConvexDenseNetwork, DenseNetwork, ResDenseNetwork
 from simulai.residuals import SymbolicOperator
 
 

--- a/examples/Sampling/scripts/hamiltonian_sampling_MNIST.py
+++ b/examples/Sampling/scripts/hamiltonian_sampling_MNIST.py
@@ -6,8 +6,7 @@ import numpy as np
 from simulai.file import SPFile
 from simulai.metrics import L2Norm
 from simulai.optimization import Optimizer
-from simulai.sampling import (HMC, G_metric, HamiltonianEquations,
-                              LeapFrogIntegrator)
+from simulai.sampling import HMC, G_metric, HamiltonianEquations, LeapFrogIntegrator
 
 
 def model():

--- a/simulai/io.py
+++ b/simulai/io.py
@@ -23,8 +23,7 @@ from numpy.lib import recfunctions
 from torch import Tensor
 
 from simulai.abstract import DataPreparer, Dataset
-from simulai.batching import (batchdomain_constructor,
-                              indices_batchdomain_constructor)
+from simulai.batching import batchdomain_constructor, indices_batchdomain_constructor
 from simulai.metrics import MemorySizeEval
 
 """
@@ -553,7 +552,7 @@ class ScalerReshaper(Reshaper):
         Examples:
         ---------
         >>> reshaper = ScalerReshaper(bias=10, scale=2)
-        >>> reshaper._get_structured_bias_scale(np.dtype([('a', np.float), ('b', np.float)]))
+        >>> reshaper._get_structured_bias_scale(np.dtype([('a', float), ('b', float)]))
         ({'a': 10, 'b': 10}, {'a': 2, 'b': 2})
 
         NOTE:
@@ -2142,7 +2141,7 @@ class MakeTensor:
         """
 
         if type(input_data) == np.ndarray:
-            input_data = torch.from_numpy(input_data.astype(np.float32))
+            input_data = torch.from_numpy(input_data.astype("float32"))
 
             inputs_list = self._make_tensor(input_data=input_data, device=device)
 

--- a/simulai/math/kansas.py
+++ b/simulai/math/kansas.py
@@ -55,8 +55,8 @@ class Kansas:
             kernel  # kernel function or string specifiying the type of kernel function
         )
         self.eps = eps  # tolerance to take off interpolation matrices elements
-        self.points = np.float32(points)  # interpolation points
-        self.centers = np.float32(centers)  # kernel centers
+        self.points = (points).astype("float32")  # interpolation points
+        self.centers = (centers).astype("float32")  # kernel centers
         self.ndim = centers.shape[1]  # dimension of points
 
         if self.ndim != points.shape[1]:
@@ -65,7 +65,9 @@ class Kansas:
         self.f1_was_gen = False
 
         # Calculate the radial function for the combination of centers and interpolation points
-        self.r2 = np.float32(spatial.distance.cdist(points, centers, "sqeuclidean"))
+        self.r2 = (spatial.distance.cdist(points, centers, "sqeuclidean")).astype(
+            "float32"
+        )
 
         # calculate sigma based on the mean maximal distance beteewn 2 kernels or use the informed sigma
         if sigma2 == "auto":
@@ -435,7 +437,7 @@ class Kansas:
         else:
             print(" this kernel does not exist: ", kernel_type)
 
-        G = np.float32(G)
+        G = (G).astype("float32")
 
         return G
 
@@ -481,7 +483,7 @@ class Kansas:
         else:
             print(" this kernel does not exist: ", kernel_type)
 
-        Dx = np.float32(Dx)
+        Dx = (Dx).astype("float32")
 
         return Dx
 
@@ -526,7 +528,7 @@ class Kansas:
         else:
             print(" this kernel does not exist: ", kernel_type)
 
-        Dxy = np.float32(Dxy)
+        Dxy = (Dxy).astype("float32")
 
         return Dxy
 
@@ -571,7 +573,7 @@ class Kansas:
         else:
             print(" thins kernel does not exist: ", kernel_type)
 
-        Dxx = np.float32(Dxx)
+        Dxx = (Dxx).astype("float32")
 
         return Dxx
 
@@ -616,6 +618,6 @@ class Kansas:
         else:
             print(" thins kernel does not exist: ", kernel_type)
 
-        L = np.float32(L)
+        L = (L).astype("float32")
 
         return L

--- a/simulai/metrics.py
+++ b/simulai/metrics.py
@@ -686,7 +686,7 @@ class MeanEvaluation:
             data = dataset[slice(*batch)]
 
             if data_preparer is None:
-                data_ = data.view(np.float)
+                data_ = data.view(float)
                 data_flatten = data_.reshape(-1, np.product(data_.shape[1:]))
             else:
                 data_flatten = data_preparer.prepare_input_structured_data(data)

--- a/simulai/models/__init__.py
+++ b/simulai/models/__init__.py
@@ -15,11 +15,20 @@
 from simulai import engine
 
 if engine == "pytorch":
-    from ._pytorch_models import (AutoencoderCNN, AutoencoderKoopman,
-                                  AutoencoderMLP, AutoencoderVariational,
-                                  DeepONet, FlexibleDeepONet, ImprovedDeepONet,
-                                  ImprovedDenseNetwork, MetaModel, ModelMaker,
-                                  MoEPool, ResDeepONet)
+    from ._pytorch_models import (
+        AutoencoderCNN,
+        AutoencoderKoopman,
+        AutoencoderMLP,
+        AutoencoderVariational,
+        DeepONet,
+        FlexibleDeepONet,
+        ImprovedDeepONet,
+        ImprovedDenseNetwork,
+        MetaModel,
+        ModelMaker,
+        MoEPool,
+        ResDeepONet,
+    )
 elif engine == "numpy":
     pass
 else:

--- a/simulai/models/_pytorch_models/__init__.py
+++ b/simulai/models/_pytorch_models/__init__.py
@@ -1,6 +1,8 @@
-from ._autoencoder import (AutoencoderCNN, AutoencoderKoopman, AutoencoderMLP,
-                           AutoencoderVariational)
-from ._deeponet import (DeepONet, FlexibleDeepONet, ImprovedDeepONet,
-                        ResDeepONet)
-from ._miscellaneous import (ImprovedDenseNetwork, MetaModel, ModelMaker,
-                             MoEPool)
+from ._autoencoder import (
+    AutoencoderCNN,
+    AutoencoderKoopman,
+    AutoencoderMLP,
+    AutoencoderVariational,
+)
+from ._deeponet import DeepONet, FlexibleDeepONet, ImprovedDeepONet, ResDeepONet
+from ._miscellaneous import ImprovedDenseNetwork, MetaModel, ModelMaker, MoEPool

--- a/simulai/models/_pytorch_models/_autoencoder.py
+++ b/simulai/models/_pytorch_models/_autoencoder.py
@@ -18,8 +18,13 @@ import numpy as np
 import torch
 
 from simulai.regression import ConvolutionalNetwork, DenseNetwork, Linear
-from simulai.templates import (NetworkTemplate, as_tensor, autoencoder_auto,
-                               cnn_autoencoder_auto, mlp_autoencoder_auto)
+from simulai.templates import (
+    NetworkTemplate,
+    as_tensor,
+    autoencoder_auto,
+    cnn_autoencoder_auto,
+    mlp_autoencoder_auto,
+)
 
 ########################################
 ### Some usual AutoEncoder architectures

--- a/simulai/optimization/_losses.py
+++ b/simulai/optimization/_losses.py
@@ -548,12 +548,12 @@ class PIRMSELoss(LossBasics):
 
         if type(input_data) == dict:
             return {
-                key: torch.from_numpy(item.astype(np.float32)).to(device)
+                key: torch.from_numpy(item.astype("float32")).to(device)
                 for key, item in input_data.items()
             }
 
         else:
-            return torch.from_numpy(input_data.astype(np.float32)).to(device)
+            return torch.from_numpy(input_data.astype("float32")).to(device)
 
     def _to_tensor(self, *args, device: str = "cpu") -> List[torch.Tensor]:
         """
@@ -837,12 +837,12 @@ class OPIRMSELoss(LossBasics):
     ) -> Union[dict, torch.Tensor]:
         if type(input_data) == dict:
             return {
-                key: torch.from_numpy(item.astype(np.float32)).to(device)
+                key: torch.from_numpy(item.astype("float32")).to(device)
                 for key, item in input_data.items()
             }
 
         else:
-            return torch.from_numpy(input_data.astype(np.float32)).to(device)
+            return torch.from_numpy(input_data.astype("float32")).to(device)
 
     def _to_tensor(self, *args, device="cpu"):
         return [self._convert(input_data=arg, device=device) for arg in args]
@@ -1063,12 +1063,12 @@ class KAERMSELoss(LossBasics):
     ) -> Union[dict, torch.Tensor]:
         if type(input_data) == dict:
             return {
-                key: torch.from_numpy(item.astype(np.float32)).to(device)
+                key: torch.from_numpy(item.astype("float32")).to(device)
                 for key, item in input_data.items()
             }
 
         else:
-            return torch.from_numpy(input_data.astype(np.float32)).to(device)
+            return torch.from_numpy(input_data.astype("float32")).to(device)
 
     def _to_tensor(self, *args, device="cpu"):
         return [self._convert(input_data=arg, device=device) for arg in args]
@@ -1271,12 +1271,12 @@ class VAERMSELoss(LossBasics):
     ) -> Union[dict, torch.Tensor]:
         if type(input_data) == dict:
             return {
-                key: torch.from_numpy(item.astype(np.float32)).to(device)
+                key: torch.from_numpy(item.astype("float32")).to(device)
                 for key, item in input_data.items()
             }
 
         else:
-            return torch.from_numpy(input_data.astype(np.float32)).to(device)
+            return torch.from_numpy(input_data.astype("float32")).to(device)
 
     def _to_tensor(self, *args, device="cpu"):
         return [self._convert(input_data=arg, device=device) for arg in args]

--- a/simulai/optimization/_optimization.py
+++ b/simulai/optimization/_optimization.py
@@ -721,7 +721,7 @@ class ScipyInterface:
         if type(parameters[0]) == torch.Tensor:
             return np.hstack(
                 [
-                    param.detach().numpy().astype(np.float64).flatten()
+                    param.detach().numpy().astype("float64").flatten()
                     for param in parameters
                 ]
             )

--- a/simulai/optimization/_optimization.py
+++ b/simulai/optimization/_optimization.py
@@ -46,14 +46,14 @@ def _convert_tensor_format(method):
             input_data_ = input_data
 
         elif isinstance(input_data, np.ndarray):
-            input_data_ = torch.from_numpy(input_data.astype(np.float32))
+            input_data_ = torch.from_numpy(input_data.astype("float32"))
 
         elif isinstance(input_data, dict):
             input_data_ = dict()
 
             for key, item in input_data.items():
                 if type(item) == np.ndarray:
-                    input_data_[key] = torch.from_numpy(item.astype(np.float32))
+                    input_data_[key] = torch.from_numpy(item.astype("float32"))
 
                 else:
                     input_data_[key] = item
@@ -64,14 +64,14 @@ def _convert_tensor_format(method):
             )
 
         if isinstance(target_data, np.ndarray):
-            target_data_ = torch.from_numpy(target_data.astype(np.float32))
+            target_data_ = torch.from_numpy(target_data.astype("float32"))
         else:
             target_data_ = target_data
 
         if validation_data is not None:
             if isinstance(validation_data[0], np.ndarray):
                 validation_data_ = tuple(
-                    [torch.from_numpy(j.astype(np.float32)) for j in validation_data]
+                    [torch.from_numpy(j.astype("float32")) for j in validation_data]
                 )
             else:
                 validation_data_ = validation_data

--- a/simulai/regression/__init__.py
+++ b/simulai/regression/__init__.py
@@ -16,6 +16,7 @@ from simulai import engine
 
 from ._affine import AffineMapping
 from ._elm import ELM
+
 # No back-propagation mechanisms
 from ._esn import DeepEchoStateNetwork, EchoStateNetwork, WideEchoStateNetwork
 from ._extended_opinf import ExtendedOpInf
@@ -27,8 +28,14 @@ assert engine is not None, "The variable engine was not defined."
 
 if engine == "pytorch":
     from ._pytorch._conv import ConvolutionalNetwork, ResConvolutionalNetwork
-    from ._pytorch._dense import (SLFNN, ConvexDenseNetwork, DenseNetwork,
-                                  Linear, ResDenseNetwork, ShallowNetwork)
+    from ._pytorch._dense import (
+        SLFNN,
+        ConvexDenseNetwork,
+        DenseNetwork,
+        Linear,
+        ResDenseNetwork,
+        ShallowNetwork,
+    )
     from ._pytorch._koopman import AutoEncoderKoopman, KoopmanNetwork
     from ._pytorch._numpy import LinearNumpy
     from ._pytorch._opinf import OpInfNetwork

--- a/simulai/templates/__init__.py
+++ b/simulai/templates/__init__.py
@@ -14,14 +14,24 @@
 
 from simulai import engine
 
-from ._templates import (NetworkInstanceGen, ReservoirComputing,
-                         autoencoder_auto, cnn_autoencoder_auto,
-                         mlp_autoencoder_auto)
+from ._templates import (
+    NetworkInstanceGen,
+    ReservoirComputing,
+    autoencoder_auto,
+    cnn_autoencoder_auto,
+    mlp_autoencoder_auto,
+)
 
 if engine == "pytorch":
-    from ._pytorch_network import (ConvNetworkTemplate, HyperTrainTemplate,
-                                   NetworkTemplate, as_array, as_tensor,
-                                   channels_dim, guarantee_device)
+    from ._pytorch_network import (
+        ConvNetworkTemplate,
+        HyperTrainTemplate,
+        NetworkTemplate,
+        as_array,
+        as_tensor,
+        channels_dim,
+        guarantee_device,
+    )
 elif engine == "numpy":
     pass
 else:

--- a/simulai/templates/_pytorch_network.py
+++ b/simulai/templates/_pytorch_network.py
@@ -260,14 +260,14 @@ class NetworkTemplate(torch.nn.Module):
         for ll, layer in enumerate(self.layers_map):
             self.layers[ll].weight = Parameter(
                 data=torch.from_numpy(
-                    parameters[self.stitch_idx[layer[0]]].astype(np.float32)
+                    parameters[self.stitch_idx[layer[0]]].astype("float32")
                 ),
                 requires_grad=True,
             )
 
             self.layers[ll].bias = Parameter(
                 data=torch.from_numpy(
-                    parameters[self.stitch_idx[layer[1]]].astype(np.float32)
+                    parameters[self.stitch_idx[layer[1]]].astype("float32")
                 ),
                 requires_grad=True,
             )
@@ -342,7 +342,7 @@ def as_tensor(method):
             return method(self, input_data, **kwargs)
 
         elif isinstance(input_data, np.ndarray):
-            input_data_ = torch.from_numpy(input_data.astype(np.float32))
+            input_data_ = torch.from_numpy(input_data.astype("float32"))
 
             return method(self, input_data_, **kwargs)
 
@@ -381,7 +381,7 @@ def as_array(method):
 def guarantee_device(method):
     def inside(self, **kwargs) -> callable:
         kwargs_ = {
-            key: torch.from_numpy(value.astype(np.float32)).to(self.device)
+            key: torch.from_numpy(value.astype("float32")).to(self.device)
             for key, value in kwargs.items()
             if isinstance(value, np.ndarray) == True
         }

--- a/simulai/workflows/__init__.py
+++ b/simulai/workflows/__init__.py
@@ -14,9 +14,12 @@
 
 from ._cloud_object_storage import CloudObjectStorage
 from ._esn_modelpool_train import (
-    ObjectiveESNIndependent, define_reservoir_configs_for_affine_training,
+    ObjectiveESNIndependent,
+    define_reservoir_configs_for_affine_training,
     optuna_assess_best_joint_solution_ESNIndependent,
-    optuna_assess_best_solution_ESNIndependent, optuna_objectiveESNIndependent)
+    optuna_assess_best_solution_ESNIndependent,
+    optuna_objectiveESNIndependent,
+)
 from ._extrapolation import StepwiseExtrapolation
 from ._h5_comparison import compute_datasets_to_reference_norm
 from ._h5_ipod import dataset_ipod, pipeline_projection_error

--- a/tests/math/test_metrics.py
+++ b/tests/math/test_metrics.py
@@ -19,8 +19,12 @@ import h5py
 import numpy as np
 import pytest
 
-from simulai.metrics import (FeatureWiseErrorNorm, L2Norm, MemorySizeEval,
-                             SampleWiseErrorNorm)
+from simulai.metrics import (
+    FeatureWiseErrorNorm,
+    L2Norm,
+    MemorySizeEval,
+    SampleWiseErrorNorm,
+)
 from simulai.utilities import make_temp_directory
 
 

--- a/tests/network/test_conv_1d.py
+++ b/tests/network/test_conv_1d.py
@@ -34,8 +34,8 @@ def generate_data(
     input_data = np.random.rand(n_samples, n_inputs, vector_size)
     output_data = np.random.rand(n_samples, n_outputs)
 
-    return torch.from_numpy(input_data.astype(np.float32)), torch.from_numpy(
-        output_data.astype(np.float32)
+    return torch.from_numpy(input_data.astype("float32")), torch.from_numpy(
+        output_data.astype("float32")
     )
 
 

--- a/tests/network/test_conv_2d.py
+++ b/tests/network/test_conv_2d.py
@@ -34,8 +34,8 @@ def generate_data(
     input_data = np.random.rand(n_samples, n_inputs, *image_size)
     output_data = np.random.rand(n_samples, n_outputs)
 
-    return torch.from_numpy(input_data.astype(np.float32)), torch.from_numpy(
-        output_data.astype(np.float32)
+    return torch.from_numpy(input_data.astype("float32")), torch.from_numpy(
+        output_data.astype("float32")
     )
 
 

--- a/tests/network/test_template_gen.py
+++ b/tests/network/test_template_gen.py
@@ -31,8 +31,8 @@ def generate_data_2d(
     input_data = np.random.rand(n_samples, n_inputs, *image_size)
     output_data = np.random.rand(n_samples, n_outputs)
 
-    return torch.from_numpy(input_data.astype(np.float32)), torch.from_numpy(
-        output_data.astype(np.float32)
+    return torch.from_numpy(input_data.astype("float32")), torch.from_numpy(
+        output_data.astype("float32")
     )
 
 
@@ -45,8 +45,8 @@ def generate_data_1d(
     input_data = np.random.rand(n_samples, n_inputs, vector_size)
     output_data = np.random.rand(n_samples, n_outputs)
 
-    return torch.from_numpy(input_data.astype(np.float32)), torch.from_numpy(
-        output_data.astype(np.float32)
+    return torch.from_numpy(input_data.astype("float32")), torch.from_numpy(
+        output_data.astype("float32")
     )
 
 

--- a/tests/normalization/test_normalization.py
+++ b/tests/normalization/test_normalization.py
@@ -2,8 +2,7 @@ from unittest import TestCase
 
 import numpy as np
 
-from simulai.normalization import (UnitaryNormalization,
-                                   UnitarySymmetricalNormalization)
+from simulai.normalization import UnitaryNormalization, UnitarySymmetricalNormalization
 
 
 class TestNormalization(TestCase):

--- a/tests/parallelism/test_modelpool_esn.py
+++ b/tests/parallelism/test_modelpool_esn.py
@@ -20,6 +20,7 @@ import random
 from unittest import TestCase
 
 import numpy as np
+
 # import optuna
 import optuna
 
@@ -27,10 +28,12 @@ from simulai.models import ModelPool
 from simulai.regression import EchoStateNetwork
 from simulai.special import reservoir_generator
 from simulai.utilities import make_temp_directory
-from simulai.workflows import (ObjectiveESNIndependent,
-                               define_reservoir_configs_for_affine_training,
-                               optuna_assess_best_solution_ESNIndependent,
-                               optuna_objectiveESNIndependent)
+from simulai.workflows import (
+    ObjectiveESNIndependent,
+    define_reservoir_configs_for_affine_training,
+    optuna_assess_best_solution_ESNIndependent,
+    optuna_objectiveESNIndependent,
+)
 
 
 class TestModelPoolESN(TestCase):

--- a/tests/preprocessing/test_batch_copy.py
+++ b/tests/preprocessing/test_batch_copy.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import os
+
 # (C) Copyright IBM Corporation 2017, 2018, 2019
 # U.S. Government Users Restricted Rights:  Use, duplication or disclosure restricted
 # by GSA ADP Schedule Contract with IBM Corp.

--- a/tests/preprocessing/test_meanevaluation.py
+++ b/tests/preprocessing/test_meanevaluation.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import os
+
 # (C) Copyright IBM Corporation 2017, 2018, 2019
 # U.S. Government Users Restricted Rights:  Use, duplication or disclosure restricted
 # by GSA ADP Schedule Contract with IBM Corp.

--- a/tests/preprocessing/test_reshaper.py
+++ b/tests/preprocessing/test_reshaper.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import os
+
 # (C) Copyright IBM Corporation 2017, 2018, 2019
 # U.S. Government Users Restricted Rights:  Use, duplication or disclosure restricted
 # by GSA ADP Schedule Contract with IBM Corp.

--- a/tests/preprocessing/test_sampler.py
+++ b/tests/preprocessing/test_sampler.py
@@ -13,6 +13,7 @@
 #     limitations under the License.
 
 import os
+
 # (C) Copyright IBM Corporation 2017, 2018, 2019
 # U.S. Government Users Restricted Rights:  Use, duplication or disclosure restricted
 # by GSA ADP Schedule Contract with IBM Corp.
@@ -64,9 +65,9 @@ class TestReshaper(TestCase):
                                 "data",
                                 shape=(Nt, Nx, Ny, 1),
                                 dtype=[
-                                    ("T", np.float),
-                                    ("X", np.float),
-                                    ("Y", np.float),
+                                    ("T", float),
+                                    ("X", float),
+                                    ("Y", float),
                                 ],
                             )
 

--- a/tests/rom/test_gappy_pca_decomposition.py
+++ b/tests/rom/test_gappy_pca_decomposition.py
@@ -18,8 +18,7 @@ import numpy as np
 
 from simulai.math.progression import gp
 from simulai.rom import GPOD
-from simulai.special import (Scattering, bidimensional_map_nonlin_3,
-                             time_function)
+from simulai.special import Scattering, bidimensional_map_nonlin_3, time_function
 
 
 class TestPCADecomposition(TestCase):

--- a/tests/rom/test_hosvd.py
+++ b/tests/rom/test_hosvd.py
@@ -19,8 +19,7 @@ import numpy as np
 from simulai.file import load_pkl
 from simulai.metrics import L2Norm
 from simulai.rom import HOSVD
-from simulai.special import (Scattering, bidimensional_map_nonlin_3,
-                             time_function)
+from simulai.special import Scattering, bidimensional_map_nonlin_3, time_function
 
 
 class TestHOSVDDecomposition(TestCase):

--- a/tests/rom/test_ipca_datapreparer.py
+++ b/tests/rom/test_ipca_datapreparer.py
@@ -24,8 +24,7 @@ from simulai.math.progression import gp
 from simulai.metrics import L2Norm, MeanEvaluation
 from simulai.rom import IPOD
 from simulai.simulation import Pipeline
-from simulai.special import (Scattering, bidimensional_map_nonlin_3,
-                             time_function)
+from simulai.special import Scattering, bidimensional_map_nonlin_3, time_function
 from simulai.utilities import make_temp_directory
 
 
@@ -53,7 +52,7 @@ class TestIPCADecomposition(TestCase):
                 dataset = fp.create_dataset(
                     "data",
                     shape=(Nt, Nx * Ny, 1),
-                    dtype=[("Z_1", np.float), ("Z_2", np.float), ("Z_3", np.float)],
+                    dtype=[("Z_1", float), ("Z_2", float), ("Z_3", float)],
                 )
 
                 batches = batchdomain_constructor([0, Nt], batch_sizes[1])

--- a/tests/rom/test_ipca_decomposition.py
+++ b/tests/rom/test_ipca_decomposition.py
@@ -24,8 +24,7 @@ from simulai.math.progression import gp
 from simulai.metrics import L2Norm
 from simulai.rom import IPOD
 from simulai.simulation import Pipeline
-from simulai.special import (Scattering, bidimensional_map_nonlin_3,
-                             time_function)
+from simulai.special import Scattering, bidimensional_map_nonlin_3, time_function
 from simulai.utilities import make_temp_directory
 
 
@@ -127,7 +126,7 @@ class TestIPCADecomposition(TestCase):
                 dataset = fp.create_dataset(
                     "data",
                     shape=(Nt, Nx * Ny, 1),
-                    dtype=[("Z_1", np.float), ("Z_2", np.float), ("Z_3", np.float)],
+                    dtype=[("Z_1", float), ("Z_2", float), ("Z_3", float)],
                 )
 
                 batches = batchdomain_constructor([0, Nt], batch_sizes[1])

--- a/tests/rom/test_pca_decomposition.py
+++ b/tests/rom/test_pca_decomposition.py
@@ -19,8 +19,7 @@ import numpy as np
 from simulai.math.filtering import SVDThreshold
 from simulai.math.progression import gp
 from simulai.rom import POD
-from simulai.special import (Scattering, bidimensional_map_nonlin_3,
-                             time_function)
+from simulai.special import Scattering, bidimensional_map_nonlin_3, time_function
 
 
 class TestPCADecomposition(TestCase):


### PR DESCRIPTION
All the occurrences of numpy.float* were replaced with the builtin float and the sanity tests were performed for numpy 1.24x. 